### PR TITLE
#7 make baseurl configurable, align email and template

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -7,7 +7,7 @@ class PasswordsController < ApplicationController
   def create
     if @user
       token = @user.generate_token_for(:password_reset)
-      UserMailer.send_password_reset_email(token).deliver_later
+      UserMailer.send_password_reset_email(@user, token).deliver_later
     end
 
     # Always return a 200 OK to prevent email enumeration attacks

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,8 +1,10 @@
 class UserMailer < ApplicationMailer
   default from: "expertizamailer@gmail.com"
 
-  def send_password_reset_email(token)
-    @reset_url = "http://localhost:3000/password_edit/check_reset_url?token=#{token}"
+  def send_password_reset_email(user, token)
+    frontend_url = ENV.fetch('FRONTEND_URL', 'http://localhost:3000')
+    @user = user
+    @reset_url = "#{frontend_url}/password_edit/check_reset_url?token=#{token}"
     mail(to: @user.email, subject: 'Expertiza password reset')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,8 @@ class User < ApplicationRecord
     end
   end
 
+  # Built-in Rails 7.1+ token generator. Token invalidates if password_salt or updated_at changes.
+  # https://api.rubyonrails.org/classes/ActiveRecord/TokenFor/ClassMethods.html
   generates_token_for :password_reset, expires_in: 15.minutes do
     password_salt&.last(10) || updated_at.to_s
   end

--- a/app/views/user_mailer/send_password_reset_email.html.erb
+++ b/app/views/user_mailer/send_password_reset_email.html.erb
@@ -4,11 +4,11 @@
 </head>
 
 <body>
-<p>Hi ,</p>
+<p>Hi <%= @user.full_name %>,</p>
 <p>Reset your password, and we'll get you on your way.</p>
 <p>To change your password, click or paste the following link into your browser:</p>
 <p><a href="<%= @reset_url %>"><%= @reset_url %></a></p>
-<p>The link will expire in 24 hours, so be sure to use it right away.</p>
+<p>The link will expire in 15 minutes, so be sure to use it right away.</p>
 </body>
 </html>
 


### PR DESCRIPTION
Fix bug where user was not passed to mailer method
Update expiration refence in email view
Make frontend_url configurable with min changes
- Note that I intentionally did not use the development.rb file since that appears to be only for Rails dependencies

Add comment to user model change
- Note that no token is stored in DB, docs ref added

completes #7 

