### PR TITLE
needed to add time_helpers to th rails_helper

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,9 @@ require 'rspec/rails'
 require 'factory_bot_rails'
 require 'database_cleaner/active_record'
 
+# Include time travel helpers
+require 'active_support/testing/time_helpers'
+
 # Override DATABASE_URL for tests to prevent remote DB errors
 if Rails.env.test?
  ENV['DATABASE_URL'] = 'mysql2://root:expertiza@127.0.0.1/reimplementation_test'
@@ -18,6 +21,7 @@ end
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
   config.before(:suite) do
     FactoryBot.factories.clear
     FactoryBot.find_definitions


### PR DESCRIPTION
Need time_helpers to be included for travel_to to work for testing expired tokens.


undle exec rspec spec/controllers/api/v1/passwords_controller_spec.rb --fail-fast=1
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's 'rails' settings.
......

Finished in 25.46 seconds (files took 29.84 seconds to load)
8 examples, 0 failures