### PR TITLE
Minimally cleaned up dead code.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,13 +68,6 @@ class User < ApplicationRecord
     user
   end
 
-  # Reset the password for the user
-  def reset_password
-    random_password = SecureRandom.alphanumeric(10)
-    user.password_digest = BCrypt::Password.create(random_password)
-    user.save
-  end
-
   # Get instructor_id of the user, if the user is TA,
   # return the id of the instructor else return the id of the user for superior roles
   def instructor_id

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -88,15 +88,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#reset_password' do
-    it 'resets the password and saves the user' do
-      old_password_digest = user.password_digest
-      user.reset_password
-      expect(user.password_digest).not_to eq(old_password_digest)
-      expect(user.save).to be_truthy
-    end
-  end
-
   describe '#instructor_id' do
     it 'returns the user id if the user is an instructor' do
       user.update(role: create(:role, :instructor))


### PR DESCRIPTION
**Problem**
When running the test suite for anything related to the password reset/forgot, I found some dead code that neither works nor is being used. The deleted code in user.rb has a bug in it. As well, it was implemented two years ago:
<img width="919" height="124" alt="image" src="https://github.com/user-attachments/assets/4d7b174a-42fd-4123-b126-ef362828c07c" />

Likewise, a password reset testcase was made for this defective code, located in user_spec.rb. This was implemented a year after the defective code:
<img width="820" height="154" alt="image" src="https://github.com/user-attachments/assets/27c18369-1242-498f-9638-71cfce5b279c" />

**Solution**
Deleted the dead code and ran the password reset mechanism to verify its operation was unaffected.