### PR TITLE
updating user_mailer_spec to prevent accessing private send method

### DIFF
--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe UserMailer, type: :mailer do
   describe 'send reset email' do
     let(:user) { create(:password_reset_user)}
     let(:token) { user.generate_token_for(:password_reset)}
-    let(:token_url) { UserMailer.new.send(:password_reset_url, token)}
 
     it 'sends email with token' do
       email = UserMailer.password_reset_email(user, token).deliver_now
@@ -13,7 +12,7 @@ RSpec.describe UserMailer, type: :mailer do
       expect(email.to).to include(user.email)
       expect(email.subject).to eq(I18n.t('password_reset.email_subject'))
       expect(email.body.encoded).to include('Expertiza password reset')
-      expect(email.body.encoded).to include(token_url)
+      expect(email.body.encoded).to include("?token=#{token}")
     end
   end
 end


### PR DESCRIPTION
rather than checking for the exact token url, checking the body of the email specifically for ?token=#{token} which still covers the scenario to ensure the token is getting included in the test


<img width="864" height="113" alt="image" src="https://github.com/user-attachments/assets/89d64abb-7cbb-4ce5-a5b6-f52dc14be380" />
