### PR TITLE
Tests updated to be more robust for token searching. Tests to come.

### DIFF
--- a/spec/controllers/api/v1/passwords_controller_spec.rb
+++ b/spec/controllers/api/v1/passwords_controller_spec.rb
@@ -13,9 +13,11 @@ RSpec.describe PasswordsController, type: :controller do
           post :create, params: { email: user.email }
         end
 
-        it 'sends a password reset email' do
-          # second parameter we're checking for it the token
-          expect(UserMailer).to have_received(:password_reset_email).with(user, a_string_matching(/[a-zA-Z0-9]+={2}-{2}[a-z0-9]+/))
+        it 'sends a password reset email with a token accepted by User.find_by_token_for' do
+          expect(UserMailer).to have_received(:password_reset_email) do |received_user, token|
+            expect(received_user).to eq(user)
+            expect(User.find_by_token_for(:password_reset, token)).to eq(user)
+          end
         end
 
         it 'returns a success message' do


### PR DESCRIPTION
Made the token lookup testcase more robust instead of being tightly coupled to one token format.

Proof of tests passing still:
```
jared@JaredsIdeaPad:~/p3_ECE517/reimplementation-back-end$ bundle exec rspec spec/controllers/api/v1/passwords_controller_spec.rb
DEPRECATION WARNING: `to_time` will always preserve the full timezone rather than offset of the receiver in Rails 8.1. To opt in to the new behavior, set `config.active_support.to_time_preserves_timezone = :zone`. (called from <top (required)> at /home/jared/p3_ECE517/reimplementation-back-end/config/environment.rb:7)
DEPRECATION WARNING: `to_time` will always preserve the full timezone rather than offset of the receiver in Rails 8.1. To opt in to the new behavior, set `config.active_support.to_time_preserves_timezone = :zone`. (called from <top (required)> at /home/jared/p3_ECE517/reimplementation-back-end/config/environment.rb:7)
...../home/jared/.local/share/mise/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/rspec-rails-8.0.2/lib/rspec/rails/matchers/have_http_status.rb:219: warning: Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.
./home/jared/.local/share/mise/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/rspec-rails-8.0.2/lib/rspec/rails/matchers/have_http_status.rb:219: warning: Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.
./home/jared/.local/share/mise/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/rspec-rails-8.0.2/lib/rspec/rails/matchers/have_http_status.rb:219: warning: Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.
.

Finished in 3.07 seconds (files took 5.29 seconds to load)
8 examples, 0 failures

JSON Coverage report generated for RSpec to /home/jared/p3_ECE517/reimplementation-back-end/coverage.         712 / 1213 LOC (58.7%) covered.
```