### PR TITLE
Making FRONTEND_URL use environment settings as requested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,11 @@
 coverage/
 rsa_keys.yml
 pg_data/
+
+# Ignore .env files
+# .env files should never be committed to prevent sensitive information from being exposed.
+# Each environment can have its own .env file, and .env.* covers all of them.
+# .env.* covers .env.development .env.test, etc
+# ** ensures that .env files are ignored regardless of their location in the directory structure.
+**/.env
+**/.env.*

--- a/README.md
+++ b/README.md
@@ -7,6 +7,73 @@ Things you may want to cover:
 
 * Ruby version - 3.4.5
 
+---
+
+## Environment Configuration
+
+Before running the application, you need to configure environment variables:
+
+1. **Copy the sample environment file:**
+   ```bash
+   cp sample.env .env
+   ```
+
+2. **Configure Frontend URL Settings:**
+   
+   Edit the `.env` file and set the following frontend variables based on your environment. These settings will override the defaults defined in `config/environments/(development|test|production).rb`:
+   
+   - **`FRONTEND_SCHEME`**: Should be `http://` for development/test or `https://` for production
+   - **`FRONTEND_DOMAIN`**: The domain where your frontend is hosted
+     - **Development/Test**: Defaults to `localhost` if not set (configured in `config/environments/development.rb` and `config/environments/test.rb`)
+     - **Staging**: Requires explicit configuration via `.env`
+     - **Production**: Defaults to `expertiza.ncsu.com` if not set (configured in `config/environments/production.rb`), can be overridden via `.env`
+   - **`FRONTEND_PORT`**: Optional port number
+     - **Development/Test**: Defaults to `3000` if not set (configured in `config/environments/development.rb` and `config/environments/test.rb`)
+     - Leave blank for standard ports (80 for HTTP, 443 for HTTPS)
+     - Set to custom port if needed (e.g., `8443` for custom HTTPS)
+   
+   **Example for local development** (using defaults, no .env needed):
+   ```bash
+   # No need to set anything - defaults will be used
+   # FRONTEND_DOMAIN defaults to 'localhost'
+   # FRONTEND_PORT defaults to 3000
+   ```
+   
+   **Example for local development** (overriding defaults via .env):
+   ```env
+   FRONTEND_SCHEME='http://'
+   FRONTEND_DOMAIN='localhost'
+   FRONTEND_PORT=3000
+   ```
+   
+   **Note:** `FRONTEND_DOMAIN` must be explicitly configured via `.env` in staging environments. In production, it defaults to `expertiza.ncsu.com` but can be overridden if needed. The application will fail to start if `FRONTEND_DOMAIN` is not set in staging.
+
+3. **Load environment variables** (optional, only needed if running outside of Docker):
+   
+   When running the Rails server outside of Docker (e.g., `rails s`), you may need to source the `.env` file to load environment variables:
+   
+   **Linux/macOS:**
+   ```bash
+   source .env
+   rails s
+   ```
+   
+   **Windows (PowerShell):**
+   ```powershell
+   Get-Content .env | ForEach-Object { if ($_ -and !$_.StartsWith("#")) { $key, $value = $_ -split '=', 2; [Environment]::SetEnvironmentVariable($key, $value) } }
+   rails s
+   ```
+   
+   **Windows (Command Prompt):**
+   ```cmd
+   for /f "tokens=1,2 delims==" %a in (type .env) do @if not "%a"=="" if not "%a:~0,1%"=="#" set %a=%b
+   rails s
+   ```
+   
+   > **Note:** If you're using Docker Compose, the `.env` file is automatically loaded, so you don't need to source it manually.
+
+---
+
 ## Development Environment
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Before running the application, you need to configure environment variables:
    
    Edit the `.env` file and set the following frontend variables based on your environment. These settings will override the defaults defined in `config/environments/(development|test|production).rb`:
    
-   - **`FRONTEND_SCHEME`**: Should be `http://` for development/test or `https://` for production
+   - **`FRONTEND_SCHEME`**: Should be `http` for development/test or `https` for production
    - **`FRONTEND_DOMAIN`**: The domain where your frontend is hosted
      - **Development/Test**: Defaults to `localhost` if not set (configured in `config/environments/development.rb` and `config/environments/test.rb`)
      - **Staging**: Requires explicit configuration via `.env`
@@ -35,13 +35,13 @@ Before running the application, you need to configure environment variables:
    **Example for local development** (using defaults, no .env needed):
    ```bash
    # No need to set anything - defaults will be used
-   # FRONTEND_DOMAIN defaults to 'localhost'
+   # FRONTEND_DOMAIN defaults to localhost
    # FRONTEND_PORT defaults to 3000
    ```
    
    **Example for local development** (overriding defaults via .env):
    ```env
-   FRONTEND_SCHEME=http://
+   FRONTEND_SCHEME=http
    FRONTEND_DOMAIN=localhost
    FRONTEND_PORT=3000
    ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Before running the application, you need to configure environment variables:
    **Note:** `FRONTEND_DOMAIN` must be explicitly configured via `.env` in staging environments. In production, it defaults to `expertiza.ncsu.com` but can be overridden if needed. The application will fail to start if `FRONTEND_DOMAIN` is not set in staging.
 
 3. **Load environment variables** (optional, only needed if running outside of Docker):
+   > **Note:**
+   > 
+   > If you're using Docker Compose, the `.env` file is automatically loaded, so you don't need to source it manually.
+
    
    When running the Rails server outside of Docker (e.g., `rails s`), you may need to source the `.env` file to load environment variables:
    
@@ -63,14 +67,6 @@ Before running the application, you need to configure environment variables:
    Get-Content .env | ForEach-Object { if ($_ -and !$_.StartsWith("#")) { $key, $value = $_ -split '=', 2; [Environment]::SetEnvironmentVariable($key, $value) } }
    rails s
    ```
-   
-   **Windows (Command Prompt):**
-   ```cmd
-   for /f "tokens=1,2 delims==" %a in (type .env) do @if not "%a"=="" if not "%a:~0,1%"=="#" set %a=%b
-   rails s
-   ```
-   
-   > **Note:** If you're using Docker Compose, the `.env` file is automatically loaded, so you don't need to source it manually.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ Before running the application, you need to configure environment variables:
    When running the Rails server outside of Docker (e.g., `rails s`), you may need to source the `.env` file to load environment variables:
    
    **Linux/macOS:**
-   ```bash
-   source .env
+   
    rails s
    ```
    

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Before running the application, you need to configure environment variables:
    
    **Example for local development** (overriding defaults via .env):
    ```env
-   FRONTEND_SCHEME='http://'
-   FRONTEND_DOMAIN='localhost'
+   FRONTEND_SCHEME=http://
+   FRONTEND_DOMAIN=localhost
    FRONTEND_PORT=3000
    ```
    

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -10,7 +10,6 @@ class UserMailer < ApplicationMailer
   private
 
   def password_reset_url(token)
-    frontend_url = ENV.fetch('FRONTEND_URL', 'http://localhost:3000')
-    "#{frontend_url}/password_edit/check_reset_url?token=#{token}"
+    "#{FRONTEND_URL}/password_edit/check_reset_url?token=#{token}"
   end
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -19,5 +19,6 @@ is_standard_port = (frontend_scheme == 'http://' && frontend_port.to_i == 80) ||
                    (frontend_scheme == 'https://' && frontend_port.to_i == 443)
 port_string = !frontend_port.blank? && !is_standard_port ? ":#{frontend_port}" : ''
 
-Object.const_set(:FRONTEND_URL, "#{frontend_scheme}#{frontend_domain}#{port_string}")
-
+unless Object.const_defined?(:FRONTEND_URL)
+  FRONTEND_URL = "#{frontend_scheme}#{frontend_domain}#{port_string}"
+end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -7,18 +7,13 @@ require_relative 'application'
 Rails.application.initialize!
 
 # ── Frontend URL Configuration ──
+raise "FRONTEND_DOMAIN must be configured via environment variables or config/environments/*.rb files" if Rails.configuration.x.frontend_domain.blank?
+
 # This runs after all environment files are loaded, so environment-specific defaults are available
-frontend_scheme = ENV.fetch('FRONTEND_SCHEME', 'http://')
-frontend_domain = ENV.fetch('FRONTEND_DOMAIN', nil)
-frontend_port = ENV.fetch('FRONTEND_PORT', nil)
-
-raise "FRONTEND_DOMAIN must be configured via environment variables" if frontend_domain.blank?
-
-# Build the frontend URL, omitting standard ports (80 for http, 443 for https)
-is_standard_port = (frontend_scheme == 'http://' && frontend_port.to_i == 80) ||
-                   (frontend_scheme == 'https://' && frontend_port.to_i == 443)
-port_string = !frontend_port.blank? && !is_standard_port ? ":#{frontend_port}" : ''
-
-unless Object.const_defined?(:FRONTEND_URL)
-  FRONTEND_URL = "#{frontend_scheme}#{frontend_domain}#{port_string}"
-end
+# URI::Generic.build expects nil for no port, but ENV vars are strings, so convert to int and back to handle blank/zero cases
+uri = URI::Generic.build(
+  scheme: Rails.configuration.x.frontend_scheme,
+  host:   Rails.configuration.x.frontend_domain,
+  port:   Rails.configuration.x.frontend_port.to_i.nonzero?
+)
+FRONTEND_URL = uri.to_s

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -5,3 +5,19 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+# ── Frontend URL Configuration ──
+# This runs after all environment files are loaded, so environment-specific defaults are available
+frontend_scheme = ENV.fetch('FRONTEND_SCHEME', 'http://')
+frontend_domain = ENV.fetch('FRONTEND_DOMAIN', nil)
+frontend_port = ENV.fetch('FRONTEND_PORT', nil)
+
+raise "FRONTEND_DOMAIN must be configured via environment variables" if frontend_domain.blank?
+
+# Build the frontend URL, omitting standard ports (80 for http, 443 for https)
+is_standard_port = (frontend_scheme == 'http://' && frontend_port.to_i == 80) ||
+                   (frontend_scheme == 'https://' && frontend_port.to_i == 443)
+port_string = !frontend_port.blank? && !is_standard_port ? ":#{frontend_port}" : ''
+
+Object.const_set(:FRONTEND_URL, "#{frontend_scheme}#{frontend_domain}#{port_string}")
+

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,4 +70,12 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
   config.hosts << 'localhost'
   config.hosts << "www.example.com"
+
+  # ── Frontend URL Configuration ──
+  # we use config.before_initialize to ensure this gets picked up by environment.rb
+  # Set defaults for local development (can be overridden via .env)
+  config.before_initialize do
+    ENV['FRONTEND_DOMAIN'] ||= 'localhost'
+    ENV['FRONTEND_PORT'] ||= '3000'
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,7 +74,7 @@ Rails.application.configure do
   # ── Frontend URL Configuration ──
   # Set defaults for local development (can be overridden via environment variables)
   # Rails convention recommends config.x.* for custom settings
-  config.x.frontend_scheme = ENV.fetch('FRONTEND_SCHEME', 'http://')
+  config.x.frontend_scheme = ENV.fetch('FRONTEND_SCHEME', 'http')
   config.x.frontend_domain = ENV.fetch('FRONTEND_DOMAIN', 'localhost')
   config.x.frontend_port = ENV.fetch('FRONTEND_PORT', '3000')
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,10 +72,9 @@ Rails.application.configure do
   config.hosts << "www.example.com"
 
   # ── Frontend URL Configuration ──
-  # we use config.before_initialize to ensure this gets picked up by environment.rb
-  # Set defaults for local development (can be overridden via .env)
-  config.before_initialize do
-    ENV['FRONTEND_DOMAIN'] ||= 'localhost'
-    ENV['FRONTEND_PORT'] ||= '3000'
-  end
+  # Set defaults for local development (can be overridden via environment variables)
+  # Rails convention recommends config.x.* for custom settings
+  config.x.frontend_scheme = ENV.fetch('FRONTEND_SCHEME', 'http://')
+  config.x.frontend_domain = ENV.fetch('FRONTEND_DOMAIN', 'localhost')
+  config.x.frontend_port = ENV.fetch('FRONTEND_PORT', '3000')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,4 +87,13 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # ── Frontend URL Configuration ──
+  # we use config.before_initialize to ensure this gets picked up by environment.rb
+  # Set defaults for production (can be overridden via .env)
+  config.before_initialize do
+    ENV['FRONTEND_SCHEME'] ||= 'https://'
+    ENV['FRONTEND_DOMAIN'] ||= 'expertiza.ncsu.com'
+    ENV['FRONTEND_PORT'] ||= '443'
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,7 +91,7 @@ Rails.application.configure do
   # ── Frontend URL Configuration ──
   # Set defaults for production (can be overridden via environment variables)
   # Rails convention recommends config.x.* for custom settings
-  config.x.frontend_scheme = ENV.fetch('FRONTEND_SCHEME', 'https://')
+  config.x.frontend_scheme = ENV.fetch('FRONTEND_SCHEME', 'https')
   config.x.frontend_domain = ENV.fetch('FRONTEND_DOMAIN', 'expertiza.ncsu.com')
   config.x.frontend_port = ENV.fetch('FRONTEND_PORT', nil)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,11 +89,9 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # ── Frontend URL Configuration ──
-  # we use config.before_initialize to ensure this gets picked up by environment.rb
-  # Set defaults for production (can be overridden via .env)
-  config.before_initialize do
-    ENV['FRONTEND_SCHEME'] ||= 'https://'
-    ENV['FRONTEND_DOMAIN'] ||= 'expertiza.ncsu.com'
-    ENV['FRONTEND_PORT'] ||= '443'
-  end
+  # Set defaults for production (can be overridden via environment variables)
+  # Rails convention recommends config.x.* for custom settings
+  config.x.frontend_scheme = ENV.fetch('FRONTEND_SCHEME', 'https://')
+  config.x.frontend_domain = ENV.fetch('FRONTEND_DOMAIN', 'expertiza.ncsu.com')
+  config.x.frontend_port = ENV.fetch('FRONTEND_PORT', nil)
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -64,4 +64,12 @@ Rails.application.configure do
   # config.action_view.annotate_rendered_view_with_filenames = true
   config.hosts << 'localhost'
   config.hosts << "www.example.com"
+
+  # ── Frontend URL Configuration ──
+  # we use config.before_initialize to ensure this gets picked up by environment.rb
+  # Set defaults for tests (can be overridden via .env or test setup)
+  config.before_initialize do
+    ENV['FRONTEND_DOMAIN'] ||= 'localhost'
+    ENV['FRONTEND_PORT'] ||= '3000'
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -66,10 +66,9 @@ Rails.application.configure do
   config.hosts << "www.example.com"
 
   # ── Frontend URL Configuration ──
-  # we use config.before_initialize to ensure this gets picked up by environment.rb
-  # Set defaults for tests (can be overridden via .env or test setup)
-  config.before_initialize do
-    ENV['FRONTEND_DOMAIN'] ||= 'localhost'
-    ENV['FRONTEND_PORT'] ||= '3000'
-  end
+  # Set defaults for tests (can be overridden via environment variables)
+  # Rails convention recommends config.x.* for custom settings
+  config.x.frontend_scheme = ENV.fetch('FRONTEND_SCHEME', 'http://')
+  config.x.frontend_domain = ENV.fetch('FRONTEND_DOMAIN', 'localhost')
+  config.x.frontend_port = ENV.fetch('FRONTEND_PORT', '3000')
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
   # ── Frontend URL Configuration ──
   # Set defaults for tests (can be overridden via environment variables)
   # Rails convention recommends config.x.* for custom settings
-  config.x.frontend_scheme = ENV.fetch('FRONTEND_SCHEME', 'http://')
+  config.x.frontend_scheme = ENV.fetch('FRONTEND_SCHEME', 'http')
   config.x.frontend_domain = ENV.fetch('FRONTEND_DOMAIN', 'localhost')
   config.x.frontend_port = ENV.fetch('FRONTEND_PORT', '3000')
 end

--- a/sample.env
+++ b/sample.env
@@ -4,7 +4,7 @@
 FRONTEND_SCHEME=
 # The domain of the front-end
 # Defaults: 'localhost' in development/test, 'expertiza.ncsu.com' in production
-# REQUIRED in staging - must be explicitly set
+# Should be explicitly set in non-development environments (e.g. staging, production)
 # Examples: 'localhost' (dev/test), 'staging.expertiza.ncsu.edu' (staging), 'expertiza.ncsu.com' (production)
 FRONTEND_DOMAIN=
 # Optional: Port number for the frontend service

--- a/sample.env
+++ b/sample.env
@@ -1,3 +1,18 @@
+# ── Frontend Configuration ──
+# Scheme should be either 'http://' or 'https://'
+# Defaults: 'http://' in development/test, 'https://' in production
+FRONTEND_SCHEME=
+# The domain of the front-end
+# Defaults: 'localhost' in development/test, 'expertiza.ncsu.com' in production
+# REQUIRED in staging - must be explicitly set
+# Examples: 'localhost' (dev/test), 'staging.expertiza.ncsu.edu' (staging), 'expertiza.ncsu.com' (production)
+FRONTEND_DOMAIN=
+# Optional: Port number for the frontend service
+# Defaults: 3000 in development/test, omitted (standard port) in production
+# Omit this (or leave blank) to use standard ports (80 for http, 443 for https)
+# Examples: '3000' (dev/test), '8443' (custom HTTPS port)
+FRONTEND_PORT=
+
 # ── Mailer Configuration ──
 # All values are optional in development; see config/application.rb for defaults.
 # In production, set at minimum MAILER_SERVER, MAILER_USER, and MAILER_PASSWORD.

--- a/sample.env
+++ b/sample.env
@@ -1,6 +1,6 @@
 # ── Frontend Configuration ──
-# Scheme should be either 'http://' or 'https://'
-# Defaults: 'http://' in development/test, 'https://' in production
+# Scheme should be either 'http' or 'https'
+# Defaults: 'http' in development/test, 'https' in production
 FRONTEND_SCHEME=
 # The domain of the front-end
 # Defaults: 'localhost' in development/test, 'expertiza.ncsu.com' in production

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe UserMailer, type: :mailer do
       expect(FRONTEND_URL).to match(%r{^https?://})
 
       email = UserMailer.password_reset_email(user, token).deliver_now
-      expected_reset_url_pattern = %r{#{Regexp.escape(FRONTEND_URL)}/[a-z_/]+\?token=#{token}}
+      expected_reset_url_pattern = %r{#{Regexp.escape(FRONTEND_URL)}/[a-z_/]+\?token=#{Regexp.escape(token)}}
       expect(email.body.encoded).to match(expected_reset_url_pattern)
     end
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -12,8 +12,17 @@ RSpec.describe UserMailer, type: :mailer do
       expect(email.to).to include(user.email)
       expect(email.subject).to eq(I18n.t('password_reset.email_subject'))
       expect(email.body.encoded).to include('Expertiza password reset')
-      expect(email.body.encoded).to include(FRONTEND_URL)
       expect(email.body.encoded).to include("?token=#{token}")
+    end
+
+    it 'builds reset link from configured frontend base URL' do
+      # Verify FRONTEND_URL constant is properly configured (defaults from config/environments/test.rb)
+      expect(FRONTEND_URL).to be_present
+      expect(FRONTEND_URL).to match(%r{^https?://})
+
+      email = UserMailer.password_reset_email(user, token).deliver_now
+      expected_reset_url_pattern = %r{#{Regexp.escape(FRONTEND_URL)}/[a-z_/]+\?token=#{token}}
+      expect(email.body.encoded).to match(expected_reset_url_pattern)
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe UserMailer, type: :mailer do
       expect(email.to).to include(user.email)
       expect(email.subject).to eq(I18n.t('password_reset.email_subject'))
       expect(email.body.encoded).to include('Expertiza password reset')
+      expect(email.body.encoded).to include(FRONTEND_URL)
       expect(email.body.encoded).to include("?token=#{token}")
     end
   end


### PR DESCRIPTION
## Addressing this comment:
line 13 - Falling back to http://localhost:3000/ here is risky outside local development. If FRONTEND_URL is missing in staging/production, the system will silently send broken localhost reset links to real users instead of failing fast. Consider moving this into environment-specific app config and raising when it is missing outside development/test.

---

- updated .gitignore to not capture .env and .env.* files
- added FRONTEND_(SCHEME|DOMAIN|PORT) to sample.env with descriptions about each
- updated the README.md file to include environment setup since this configuration will be important going forward
- updated the user_mailer.rb to use the new FRONTEND_URL constant from environment.rb

## environment.rb
- we add the frontend configuration to the environment.rb file
- defaults are read from each environment config, but can be overridden by the .env file
- If the FRONTEND_DOMAIN isn't set, then we raise a configuration error
- dev/test set the frontend port to 3000 by default
- if the scheme has a standard port we don't add it to the url, but if it isn't a standard port and isn't nil then we append it to the frontend url


<img width="1044" height="196" alt="image" src="https://github.com/user-attachments/assets/8f2f11b8-75dc-48ec-a6f4-1ad3ab7472d5" />
