### PR TITLE
remove discovery option, assume always true to match OIDC spec

### DIFF
--- a/app/controllers/oidc_login_controller.rb
+++ b/app/controllers/oidc_login_controller.rb
@@ -102,7 +102,7 @@ class OidcLoginController < ApplicationController
   end
 
   def discover(provider)
-    # Cache discovery per provider at app level
+    # Avoid duplicate discovery calls within the same request
     @discoveries ||= {}
     @discoveries[provider["issuer"]] ||=
       OpenIDConnect::Discovery::Provider::Config.discover!(provider["issuer"])

--- a/config/oidc_providers.yml
+++ b/config/oidc_providers.yml
@@ -6,7 +6,6 @@ providers:
     client_secret: <%= ENV['GOOG_CLIENT_SECRET'] %>
     redirect_uri: http://localhost:3000/auth/callback
     scopes: openid email profile
-    discovery: true
 
 # Add more providers here:
   # okta:
@@ -17,4 +16,3 @@ providers:
   #   client_secret: <%= ENV['OKTA_OIDC_CLIENT_SECRET'] %>
   #   redirect_uri: <%= ENV['OKTA_OIDC_REDIRECT_URI'] %>
   #   scopes: openid email profile
-  #   discovery: true


### PR DESCRIPTION
Remove unused OIDC discovery config option https://github.com/johnmweisz/reimplementation-back-end/issues/49

- Removed the discovery config item, as the code already assumes it is always enabled.
- This is safe because the OIDC spec requires discovery, and we don't intend to support non-standard flows.
- Fixed a misleading comment that described discovery as "cached", in practice, it only persists for the lifetime of a single request. True caching would be more complicated since keys can rotate without notice causing failures.