### PR TITLE
OIDC request with username

### DIFF
--- a/app/controllers/oidc_login_controller.rb
+++ b/app/controllers/oidc_login_controller.rb
@@ -2,45 +2,55 @@ class OidcLoginController < ApplicationController
   skip_before_action :authenticate_request!
 
   rescue_from OidcConfig::ProviderNotFound do |e|
-    render json: { error: e.message }, status: :not_found
+    render_error e.message, status: :not_found
   end
 
   rescue_from OpenIDConnect::Discovery::DiscoveryFailed, Rack::OAuth2::Client::Error do |e|
-    render json: { error: "Provider communication failed: #{e.message}" }, status: :bad_gateway
+    render_error "Provider communication failed: #{e.message}", status: :bad_gateway
+  end
+
+  rescue_from ActionController::ParameterMissing do |e|
+    render_error e.message, status: :bad_request
   end
 
   # GET /auth/providers
+  # Returns only public info (id, name) — no secrets or endpoints
   def providers
     render json: OidcConfig.public_list
   end
 
   # POST /auth/client-select
+  # Username is required because emails are not unique
   # This is a good candidate for rate limiting
   def client_select
-    authorization_uri = OidcRequest.authorization_uri_for!(provider_key: params[:provider])
+    provider = params.require(:provider)
+    username = params.require(:username)
 
+    authorization_uri = OidcRequest.authorization_uri_for!(
+      provider_key: provider,
+      username: username
+    )
     render json: { redirect_uri: authorization_uri }
   end
 
   # POST /auth/callback
+  # Returns a generic error for all failure modes to avoid leaking
+  # whether the state, user, or token verification was the cause
   def callback
-    # Look up and consume the auth request
-    oidc_request = OidcRequest.consume_recent_by_state!(params[:state])
+    state = params.require(:state)
+    code = params.require(:code)
 
-    # Match to existing user by email
-    email = oidc_request.verified_email_from_code!(provider_key: oidc_request.provider, code: params[:code])
-    user  = User.find_by(email: email)
+    oidc_request = OidcRequest.consume_recent_by_state!(state)
+    user = oidc_request.authenticate_user!(code: code)
+    render json: { token: user.generate_jwt }, status: :ok
+  rescue ActiveRecord::RecordNotFound, OidcRequest::AuthenticationError,
+    OpenIDConnect::ResponseObject::IdToken::InvalidToken
+    render_error "Authentication failed", status: :unauthorized
+  end
 
-    if user
-      token = user.generate_jwt
-      render json: { token: }, status: :ok
-    else
-      render json: { error: "No account found for #{email}" }, status: :not_found
-    end
+  private
 
-  rescue ActiveRecord::RecordNotFound
-    render json: { error: "Invalid or expired login request" }, status: :unprocessable_entity
-  rescue OpenIDConnect::ResponseObject::IdToken::InvalidToken => e
-    render json: { error: "Token verification failed: #{e.message}" }, status: :unauthorized
+  def render_error(message, status:)
+    render json: { error: message }, status: status
   end
 end

--- a/app/controllers/oidc_login_controller.rb
+++ b/app/controllers/oidc_login_controller.rb
@@ -21,6 +21,7 @@ class OidcLoginController < ApplicationController
 
   # POST /auth/client-select
   # Username is required because emails are not unique
+  # Provider only knows email
   # This is a good candidate for rate limiting
   def client_select
     provider = params.require(:provider)

--- a/app/controllers/oidc_login_controller.rb
+++ b/app/controllers/oidc_login_controller.rb
@@ -44,7 +44,8 @@ class OidcLoginController < ApplicationController
     user = oidc_request.authenticate_user!(code: code)
     render json: { token: user.generate_jwt }, status: :ok
   rescue ActiveRecord::RecordNotFound, OidcRequest::AuthenticationError,
-    OpenIDConnect::ResponseObject::IdToken::InvalidToken
+    OpenIDConnect::ResponseObject::IdToken::InvalidToken,
+    OidcConfig::ProviderNotFound
     render_error "Authentication failed", status: :unauthorized
   end
 

--- a/app/models/oidc_request.rb
+++ b/app/models/oidc_request.rb
@@ -79,7 +79,10 @@ class OidcRequest < ApplicationRecord
       raise AuthenticationError, "Email not verified by provider"
     end
 
-    claims["email"]
+    email = claims["email"].to_s.strip
+    raise AuthenticationError, "Email missing from provider response" if email.blank?
+
+    email
   end
 
   # Matches on both username from input and email from id_token because emails are not unique

--- a/app/models/oidc_request.rb
+++ b/app/models/oidc_request.rb
@@ -77,7 +77,7 @@ class OidcRequest < ApplicationRecord
   # Matches on both username from input and email from id_token because emails are not unique
   def authenticate_user!(code:)
     email = verified_email_from_code!(provider_key: provider, code: code)
-    User.find_by(name: username, email: email) ||
+    User.where("LOWER(name) = ? AND LOWER(email) = ?", username.downcase, email.downcase).first ||
       raise(AuthenticationError, "No account found for #{username} with email #{email}")
   end
 

--- a/app/models/oidc_request.rb
+++ b/app/models/oidc_request.rb
@@ -11,6 +11,7 @@ class OidcRequest < ApplicationRecord
   end
 
   # Atomically finds and deletes the request to prevent replay attacks
+  # Raises RecordNotFound if entry does not exist
   def self.consume_recent_by_state!(state)
     transaction do
       request = where("created_at > ?", VALIDITY_WINDOW.ago).lock.find_by!(state: state)

--- a/app/models/oidc_request.rb
+++ b/app/models/oidc_request.rb
@@ -1,12 +1,19 @@
 class OidcRequest < ApplicationRecord
   class AuthenticationError < StandardError; end
 
-  scope :recent, ->(window = 5.minutes) { where("created_at > ?", window.ago) }
+  VALIDITY_WINDOW = 5.minutes
+  CLEANUP_PROBABILITY = 0.10
+
+  after_create :maybe_enqueue_stale_cleanup
+
+  def self.delete_stale
+    where("created_at <= ?", VALIDITY_WINDOW.ago).delete_all
+  end
 
   # Atomically finds and deletes the request to prevent replay attacks
-  def self.consume_recent_by_state!(state, window: 5.minutes)
+  def self.consume_recent_by_state!(state)
     transaction do
-      request = recent(window).lock.find_by!(state: state)
+      request = where("created_at > ?", VALIDITY_WINDOW.ago).lock.find_by!(state: state)
       request.destroy!
       request
     end
@@ -91,5 +98,11 @@ class OidcRequest < ApplicationRecord
       token_endpoint: discovery.token_endpoint,
       userinfo_endpoint: discovery.userinfo_endpoint
     )
+  end
+
+  private
+
+  def maybe_enqueue_stale_cleanup
+    CleanupStaleOidcRequestsJob.perform_later if rand < CLEANUP_PROBABILITY
   end
 end

--- a/app/models/oidc_request.rb
+++ b/app/models/oidc_request.rb
@@ -1,6 +1,9 @@
 class OidcRequest < ApplicationRecord
+  class AuthenticationError < StandardError; end
+
   scope :recent, ->(window = 5.minutes) { where("created_at > ?", window.ago) }
 
+  # Atomically finds and deletes the request to prevent replay attacks
   def self.consume_recent_by_state!(state, window: 5.minutes)
     transaction do
       request = recent(window).lock.find_by!(state: state)
@@ -9,7 +12,9 @@ class OidcRequest < ApplicationRecord
     end
   end
 
-  def self.authorization_uri_for!(provider_key:)
+  # Generates PKCE, state, and nonce — stores them for callback verification
+  # PKCE is always sent; providers that don't support it will ignore the extra params
+  def self.authorization_uri_for!(provider_key:, username:)
     provider = OidcConfig.find(provider_key)
     discovery = OpenIDConnect::Discovery::Provider::Config.discover!(provider["issuer"])
     client = new_client(provider, discovery: discovery)
@@ -25,7 +30,8 @@ class OidcRequest < ApplicationRecord
       state: state,
       nonce: nonce,
       code_verifier: code_verifier,
-      provider: provider_key
+      provider: provider_key,
+      username: username
     )
 
     client.authorization_uri(
@@ -37,6 +43,10 @@ class OidcRequest < ApplicationRecord
     )
   end
 
+  # Exchanges the authorization code for tokens, then verifies:
+  #   - ID token signature via provider JWKS
+  #   - Issuer, audience (client_id), and nonce claims
+  #   - email_verified claim if the provider includes it
   def verified_email_from_code!(provider_key:, code:)
     provider = OidcConfig.find(provider_key)
     discovery = OpenIDConnect::Discovery::Provider::Config.discover!(provider["issuer"])
@@ -55,9 +65,23 @@ class OidcRequest < ApplicationRecord
       nonce: nonce
     )
 
-    id_token.raw_attributes["email"]
+    claims = id_token.raw_attributes
+
+    if claims.key?("email_verified") && claims["email_verified"] != true
+      raise AuthenticationError, "Email not verified by provider"
+    end
+
+    claims["email"]
   end
 
+  # Matches on both username from input and email from id_token because emails are not unique
+  def authenticate_user!(code:)
+    email = verified_email_from_code!(provider_key: provider, code: code)
+    User.find_by(name: username, email: email) ||
+      raise(AuthenticationError, "No account found for #{username} with email #{email}")
+  end
+
+  # Internal: builds an OpenIDConnect::Client from provider config and discovery
   def self.new_client(provider, discovery:)
     OpenIDConnect::Client.new(
       identifier: provider["client_id"],

--- a/db/migrate/20260416184458_add_username_to_oidc_requests.rb
+++ b/db/migrate/20260416184458_add_username_to_oidc_requests.rb
@@ -1,0 +1,5 @@
+class AddUsernameToOidcRequests < ActiveRecord::Migration[8.0]
+  def change
+    add_column :oidc_requests, :username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_11_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_16_184458) do
   create_table "account_requests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "username"
     t.string "full_name"
@@ -247,6 +247,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_11_120000) do
     t.string "provider"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username"
     t.index ["state"], name: "index_oidc_requests_on_state"
   end
 

--- a/spec/models/oidc_request_spec.rb
+++ b/spec/models/oidc_request_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe OidcRequest, type: :model do
   include RolesHelper
+
   let(:provider) do
     {
       'display_name' => 'Google NCSU',
@@ -32,7 +33,7 @@ RSpec.describe OidcRequest, type: :model do
     allow(OpenIDConnect::Client).to receive(:new).and_return(client)
   end
 
-  # ─── Helper ─────────────────────────────────────────────────────────
+  # ─── Helpers ────────────────────────────────────────────────────────
 
   def create_request(state: 'state', nonce: 'nonce', verifier: 'verifier',
                      provider: 'google-ncsu', username: 'oidcuser')
@@ -87,20 +88,46 @@ RSpec.describe OidcRequest, type: :model do
       expect(described_class.find_by(id: recent_request.id)).to be_present
     end
 
-    it 'supports a custom recency window' do
-      recent_request.update_columns(created_at: 10.minutes.ago)
-
-      consumed = described_class.consume_recent_by_state!('recent-state', window: 15.minutes)
-
-      expect(consumed.id).to eq(recent_request.id)
-      expect(described_class.find_by(id: recent_request.id)).to be_nil
-    end
-
     it 'prevents replay by destroying the row on consumption' do
       described_class.consume_recent_by_state!('recent-state')
 
       expect { described_class.consume_recent_by_state!('recent-state') }
         .to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  # ─── .delete_stale ──────────────────────────────────────────────────
+
+  describe '.delete_stale' do
+    it 'deletes rows older than the validity window and preserves fresh rows' do
+      fresh = create_request(state: 'fresh')
+      stale = create_request(state: 'stale')
+      stale.update_columns(created_at: 10.minutes.ago)
+
+      described_class.delete_stale
+
+      expect(described_class.find_by(id: fresh.id)).to be_present
+      expect(described_class.find_by(id: stale.id)).to be_nil
+    end
+  end
+
+  # ─── after_create :maybe_enqueue_stale_cleanup ──────────────────────
+
+  describe 'probabilistic cleanup on create' do
+    it 'enqueues CleanupStaleOidcRequestsJob when rand falls under the threshold' do
+      allow_any_instance_of(described_class).to receive(:rand).and_return(0.0)
+
+      expect(CleanupStaleOidcRequestsJob).to receive(:perform_later)
+
+      create_request(state: 'any')
+    end
+
+    it 'does not enqueue when rand falls above the threshold' do
+      allow_any_instance_of(described_class).to receive(:rand).and_return(0.99)
+
+      expect(CleanupStaleOidcRequestsJob).not_to receive(:perform_later)
+
+      create_request(state: 'any')
     end
   end
 

--- a/spec/models/oidc_request_spec.rb
+++ b/spec/models/oidc_request_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe OidcRequest, type: :model do
+  include RolesHelper
   let(:provider) do
     {
       'display_name' => 'Google NCSU',
@@ -27,19 +28,43 @@ RSpec.describe OidcRequest, type: :model do
 
   before do
     allow(OpenIDConnect::Discovery::Provider::Config).to receive(:discover!)
-      .with('https://accounts.google.com').and_return(discovery)
+                                                           .with('https://accounts.google.com').and_return(discovery)
     allow(OpenIDConnect::Client).to receive(:new).and_return(client)
   end
 
+  # ─── Helper ─────────────────────────────────────────────────────────
+
+  def create_request(state: 'state', nonce: 'nonce', verifier: 'verifier',
+                     provider: 'google-ncsu', username: 'oidcuser')
+    described_class.create!(
+      state: state,
+      nonce: nonce,
+      code_verifier: verifier,
+      provider: provider,
+      username: username
+    )
+  end
+
+  def stub_token_exchange(email:, email_verified: nil)
+    allow(client).to receive(:authorization_code=)
+    allow(client).to receive(:access_token!)
+                       .and_return(instance_double(OpenIDConnect::AccessToken, id_token: 'fake.id.token'))
+
+    claims = { 'email' => email }
+    claims['email_verified'] = email_verified unless email_verified.nil?
+
+    id_token_obj = instance_double(
+      OpenIDConnect::ResponseObject::IdToken,
+      raw_attributes: claims
+    )
+    allow(id_token_obj).to receive(:verify!)
+    allow(OpenIDConnect::ResponseObject::IdToken).to receive(:decode).and_return(id_token_obj)
+  end
+
+  # ─── .consume_recent_by_state! ──────────────────────────────────────
+
   describe '.consume_recent_by_state!' do
-    let!(:recent_request) do
-      OidcRequest.create!(
-        state: 'recent-state',
-        nonce: 'nonce',
-        code_verifier: 'verifier',
-        provider: 'google-ncsu'
-      )
-    end
+    let!(:recent_request) { create_request(state: 'recent-state') }
 
     it 'returns and destroys a recent request matching state' do
       consumed = described_class.consume_recent_by_state!('recent-state')
@@ -58,6 +83,7 @@ RSpec.describe OidcRequest, type: :model do
 
       expect { described_class.consume_recent_by_state!('recent-state') }
         .to raise_error(ActiveRecord::RecordNotFound)
+      # Expired row is not deleted — only consumed rows are destroyed
       expect(described_class.find_by(id: recent_request.id)).to be_present
     end
 
@@ -69,74 +95,160 @@ RSpec.describe OidcRequest, type: :model do
       expect(consumed.id).to eq(recent_request.id)
       expect(described_class.find_by(id: recent_request.id)).to be_nil
     end
+
+    it 'prevents replay by destroying the row on consumption' do
+      described_class.consume_recent_by_state!('recent-state')
+
+      expect { described_class.consume_recent_by_state!('recent-state') }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
+
+  # ─── .authorization_uri_for! ────────────────────────────────────────
 
   describe '.authorization_uri_for!' do
     before do
       allow(OidcConfig).to receive(:find).with('google-ncsu').and_return(provider)
     end
 
-    it 'creates auth request and returns provider authorization URI' do
+    it 'creates auth request with username and returns provider authorization URI' do
       allow(client).to receive(:authorization_uri)
-        .with(hash_including(scope: %w[openid email profile], code_challenge_method: 'S256'))
-        .and_return('https://accounts.google.com/o/oauth2/v2/auth?scope=openid+email+profile')
+                         .with(hash_including(scope: %w[openid email profile], code_challenge_method: 'S256'))
+                         .and_return('https://accounts.google.com/o/oauth2/v2/auth?scope=openid+email+profile')
 
       expect do
-        uri = described_class.authorization_uri_for!(provider_key: 'google-ncsu')
+        uri = described_class.authorization_uri_for!(provider_key: 'google-ncsu', username: 'oidcuser')
         expect(uri).to include('scope=openid+email+profile')
       end.to change(described_class, :count).by(1)
+
+      created = described_class.last
+      expect(created.username).to eq('oidcuser')
+      expect(created.provider).to eq('google-ncsu')
     end
 
     it 'uses default scopes when provider scopes are missing' do
       allow(OidcConfig).to receive(:find).with('google-ncsu')
-        .and_return(provider.merge('scopes' => nil))
+                                         .and_return(provider.merge('scopes' => nil))
       allow(client).to receive(:authorization_uri)
-        .with(hash_including(scope: %w[openid email profile], code_challenge_method: 'S256'))
-        .and_return('https://accounts.google.com/o/oauth2/v2/auth?scope=openid+email+profile')
+                         .with(hash_including(scope: %w[openid email profile], code_challenge_method: 'S256'))
+                         .and_return('https://accounts.google.com/o/oauth2/v2/auth?scope=openid+email+profile')
 
-      described_class.authorization_uri_for!(provider_key: 'google-ncsu')
+      described_class.authorization_uri_for!(provider_key: 'google-ncsu', username: 'oidcuser')
     end
   end
+
+  # ─── #verified_email_from_code! ─────────────────────────────────────
 
   describe '#verified_email_from_code!' do
     before do
       allow(OidcConfig).to receive(:find).with('google-ncsu').and_return(provider)
     end
 
-    let(:oidc_request) do
-      described_class.create!(
-        state: 'state',
-        nonce: 'nonce',
-        code_verifier: 'verifier',
-        provider: 'google-ncsu'
-      )
-    end
-
-    let(:id_token_obj) do
-      instance_double(
-        OpenIDConnect::ResponseObject::IdToken,
-        raw_attributes: { 'email' => 'oidcuser@ncsu.edu' }
-      )
-    end
+    let(:oidc_request) { create_request }
 
     it 'exchanges code, verifies token and returns email' do
-      allow(client).to receive(:authorization_code=).with('authorization-code')
-      allow(client).to receive(:access_token!).with(code_verifier: 'verifier')
-                                              .and_return(instance_double(OpenIDConnect::AccessToken, id_token: 'fake.id.token'))
-
-      allow(OpenIDConnect::ResponseObject::IdToken).to receive(:decode)
-                                                         .with('fake.id.token', discovery.jwks)
-                                                         .and_return(id_token_obj)
-      allow(id_token_obj).to receive(:verify!).with(
-        issuer: 'https://accounts.google.com',
-        client_id: 'test-client-id',
-        nonce: 'nonce'
-      )
+      stub_token_exchange(email: 'oidcuser@ncsu.edu')
 
       email = oidc_request.verified_email_from_code!(provider_key: 'google-ncsu', code: 'authorization-code')
       expect(email).to eq('oidcuser@ncsu.edu')
     end
+
+    it 'returns email when email_verified is true' do
+      stub_token_exchange(email: 'oidcuser@ncsu.edu', email_verified: true)
+
+      email = oidc_request.verified_email_from_code!(provider_key: 'google-ncsu', code: 'authorization-code')
+      expect(email).to eq('oidcuser@ncsu.edu')
+    end
+
+    it 'returns email when provider does not include email_verified claim' do
+      stub_token_exchange(email: 'oidcuser@ncsu.edu')
+
+      email = oidc_request.verified_email_from_code!(provider_key: 'google-ncsu', code: 'authorization-code')
+      expect(email).to eq('oidcuser@ncsu.edu')
+    end
+
+    it 'raises AuthenticationError when email_verified is false' do
+      stub_token_exchange(email: 'oidcuser@ncsu.edu', email_verified: false)
+
+      expect { oidc_request.verified_email_from_code!(provider_key: 'google-ncsu', code: 'authorization-code') }
+        .to raise_error(OidcRequest::AuthenticationError, /Email not verified/)
+    end
   end
+
+  # ─── #authenticate_user! ────────────────────────────────────────────
+
+  describe '#authenticate_user!' do
+    before(:each) do
+      @roles = create_roles_hierarchy
+      @institution = Institution.first || Institution.create!(name: "Test Institution")
+      allow(OidcConfig).to receive(:find).with('google-ncsu').and_return(provider)
+    end
+
+    let!(:user) do
+      User.create!(
+        name: "OidcUser", password: "password", role_id: @roles[:student].id,
+        full_name: "OIDC User", email: "OidcUser@ncsu.edu", institution: @institution
+      )
+    end
+
+    it 'matches user by username and email' do
+      oidc_request = create_request(username: 'OidcUser')
+      stub_token_exchange(email: 'OidcUser@ncsu.edu')
+
+      result = oidc_request.authenticate_user!(code: 'authorization-code')
+      expect(result.id).to eq(user.id)
+    end
+
+    it 'matches user case-insensitively on username' do
+      oidc_request = create_request(username: 'oidcuser')
+      stub_token_exchange(email: 'OidcUser@ncsu.edu')
+
+      result = oidc_request.authenticate_user!(code: 'authorization-code')
+      expect(result.id).to eq(user.id)
+    end
+
+    it 'matches user case-insensitively on email' do
+      oidc_request = create_request(username: 'OidcUser')
+      stub_token_exchange(email: 'oidcuser@ncsu.edu')
+
+      result = oidc_request.authenticate_user!(code: 'authorization-code')
+      expect(result.id).to eq(user.id)
+    end
+
+    it 'matches user case-insensitively on both username and email' do
+      oidc_request = create_request(username: 'OIDCUSER')
+      stub_token_exchange(email: 'OIDCUSER@NCSU.EDU')
+
+      result = oidc_request.authenticate_user!(code: 'authorization-code')
+      expect(result.id).to eq(user.id)
+    end
+
+    it 'raises AuthenticationError when email matches but username does not' do
+      oidc_request = create_request(username: 'wronguser')
+      stub_token_exchange(email: 'OidcUser@ncsu.edu')
+
+      expect { oidc_request.authenticate_user!(code: 'authorization-code') }
+        .to raise_error(OidcRequest::AuthenticationError, /No account found/)
+    end
+
+    it 'raises AuthenticationError when username matches but email does not' do
+      oidc_request = create_request(username: 'OidcUser')
+      stub_token_exchange(email: 'different@example.com')
+
+      expect { oidc_request.authenticate_user!(code: 'authorization-code') }
+        .to raise_error(OidcRequest::AuthenticationError, /No account found/)
+    end
+
+    it 'raises AuthenticationError when neither username nor email match' do
+      oidc_request = create_request(username: 'nobody')
+      stub_token_exchange(email: 'nobody@example.com')
+
+      expect { oidc_request.authenticate_user!(code: 'authorization-code') }
+        .to raise_error(OidcRequest::AuthenticationError, /No account found/)
+    end
+  end
+
+  # ─── .new_client ────────────────────────────────────────────────────
 
   describe '.new_client' do
     it 'builds an OpenIDConnect::Client with provider credentials and discovery endpoints' do

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe AuthenticationController, type: :request do
     post 'Logs in a user' do
       tags 'Authentication'
       consumes 'application/json'
+      security []
       parameter name: :credentials, in: :body, schema: {
         type: :object,
         properties: {

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -37,9 +37,6 @@ RSpec.describe AuthenticationController, type: :request do
         end
         let(:credentials) { { user_name: user.name, password: 'password' } }
 
-        let(:token) { user.generate_jwt }
-        let(:Authorization) { "Bearer #{token}" }
-        let(:headers) { { "Authorization" => "Bearer #{token}" } }
         run_test! do |response|
           json_response = JSON.parse(response.body)
           token = json_response['token']
@@ -70,9 +67,6 @@ RSpec.describe AuthenticationController, type: :request do
           )
         end
         let(:credentials) { { user_name: user.name, password: 'wrongpassword' } }
-        let(:token) { user.generate_jwt }
-        let(:Authorization) { "Bearer #{token}" }
-        let(:headers) { { "Authorization" => "Bearer #{token}" } }
         run_test!
       end
     end

--- a/spec/requests/oidc_login_spec.rb
+++ b/spec/requests/oidc_login_spec.rb
@@ -50,12 +50,13 @@ RSpec.describe OidcLoginController, type: :request do
     allow(OpenIDConnect::ResponseObject::IdToken).to receive(:decode).and_return(id_token_obj)
   end
 
-  def create_oidc_request(state:, provider: "google-ncsu")
+  def create_oidc_request(state:, provider: "google-ncsu", username: "oidcuser")
     OidcRequest.create!(
       state:         state,
       nonce:         "nonce-#{state}",
       code_verifier: "verifier-#{state}",
-      provider:      provider
+      provider:      provider,
+      username:      username
     )
   end
 
@@ -103,17 +104,19 @@ RSpec.describe OidcLoginController, type: :request do
       produces 'application/json'
       security []
       description <<~DESC
-        Accepts a provider key, performs OIDC discovery, generates PKCE and state parameters,
-        persists an OidcRequest for later verification, and returns the provider's authorization URL
-        that the front end should redirect the user to.
+        Accepts a provider key and username, performs OIDC discovery, generates PKCE and state
+        parameters, persists an OidcRequest for later verification, and returns the provider's
+        authorization URL that the front end should redirect the user to.
+        Username is required because emails are not unique in Expertiza.
       DESC
 
       parameter name: :body, in: :body, schema: {
         type: :object,
         properties: {
-          provider: { type: :string, example: 'google-ncsu', description: 'Key identifying the OIDC provider' }
+          provider: { type: :string, example: 'google-ncsu', description: 'Key identifying the OIDC provider' },
+          username: { type: :string, example: 'jdoe', description: 'Expertiza username for account matching' }
         },
-        required: %w[provider]
+        required: %w[provider username]
       }
 
       response '200', 'authorization redirect URI' do
@@ -123,17 +126,32 @@ RSpec.describe OidcLoginController, type: :request do
                },
                required: %w[redirect_uri]
 
-        let(:body) { { provider: "google-ncsu" } }
+        let(:body) { { provider: "google-ncsu", username: "oidcuser" } }
 
         before do
           allow(OidcRequest).to receive(:authorization_uri_for!)
-                                  .with(provider_key: "google-ncsu")
+                                  .with(provider_key: "google-ncsu", username: "oidcuser")
                                   .and_return("https://accounts.google.com/o/oauth2/v2/auth?scope=openid+email+profile")
         end
 
         run_test! do |response|
           json = JSON.parse(response.body)
           expect(json["redirect_uri"]).to be_present
+        end
+      end
+
+      response '400', 'missing required parameters' do
+        schema type: :object,
+               properties: {
+                 error: { type: :string, example: 'param is missing or the value is empty: username' }
+               },
+               required: %w[error]
+
+        let(:body) { { provider: "google-ncsu" } }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
+          expect(json["error"]).to match(/username/)
         end
       end
 
@@ -144,7 +162,7 @@ RSpec.describe OidcLoginController, type: :request do
                },
                required: %w[error]
 
-        let(:body) { { provider: "nonexistent" } }
+        let(:body) { { provider: "nonexistent", username: "oidcuser" } }
 
         before do
           allow(OidcRequest).to receive(:authorization_uri_for!)
@@ -164,7 +182,7 @@ RSpec.describe OidcLoginController, type: :request do
                },
                required: %w[error]
 
-        let(:body) { { provider: "google-ncsu" } }
+        let(:body) { { provider: "google-ncsu", username: "oidcuser" } }
 
         before do
           allow(OidcRequest).to receive(:authorization_uri_for!)
@@ -190,7 +208,8 @@ RSpec.describe OidcLoginController, type: :request do
       description <<~DESC
         Called by the front end after the user is redirected back from the identity provider.
         Exchanges the authorization code for tokens, verifies the ID token, and returns
-        a local JWT session token if the user's email matches an existing account.
+        a local JWT session token if the user's username and email match an existing account.
+        Returns a generic error for all failure modes to avoid information leakage.
       DESC
 
       parameter name: :body, in: :body, schema: {
@@ -218,7 +237,7 @@ RSpec.describe OidcLoginController, type: :request do
           )
         end
 
-        let(:oidc_request) { create_oidc_request(state: "valid-state") }
+        let(:oidc_request) { create_oidc_request(state: "valid-state", username: "oidcuser") }
         let(:body) { { state: oidc_request.state, code: "authorization-code" } }
 
         before do
@@ -234,17 +253,17 @@ RSpec.describe OidcLoginController, type: :request do
         end
       end
 
-      # ── 404 — no matching account or unknown provider ──
+      # ── 401 — authentication failed (generic for all failure modes) ──
 
-      response '404', 'no account found or unknown provider' do
+      response '401', 'authentication failed' do
         schema type: :object,
                properties: {
-                 error: { type: :string, example: 'No account found for unknown@example.com' }
+                 error: { type: :string, example: 'Authentication failed' }
                },
                required: %w[error]
 
-        context 'when no user exists for the email' do
-          let(:oidc_request) { create_oidc_request(state: "state-no-user") }
+        context 'when no user matches the username and email' do
+          let(:oidc_request) { create_oidc_request(state: "state-no-user", username: "nobody") }
           let(:body) { { state: oidc_request.state, code: "authorization-code" } }
 
           before do
@@ -255,7 +274,57 @@ RSpec.describe OidcLoginController, type: :request do
 
           run_test! do |response|
             json = JSON.parse(response.body)
-            expect(json["error"]).to match(/No account found/)
+            expect(json["error"]).to eq("Authentication failed")
+          end
+        end
+
+        context 'when email matches but username does not' do
+          let(:oidc_request) { create_oidc_request(state: "state-wrong-user", username: "wronguser") }
+          let(:body) { { state: oidc_request.state, code: "authorization-code" } }
+
+          before do
+            User.create!(
+              name: "oidcuser", password: "password", role_id: @roles[:student].id,
+              full_name: "OIDC User", email: "oidcuser@ncsu.edu", institution: @institution
+            )
+            stub_provider_config
+            stub_discovery
+            stub_token_exchange(email: "oidcuser@ncsu.edu")
+          end
+
+          run_test! do |response|
+            json = JSON.parse(response.body)
+            expect(json["error"]).to eq("Authentication failed")
+          end
+        end
+
+        context 'when state is invalid or expired' do
+          let(:body) { { state: "nonexistent-state", code: "authorization-code" } }
+
+          run_test! do |response|
+            json = JSON.parse(response.body)
+            expect(json["error"]).to eq("Authentication failed")
+          end
+        end
+
+        context 'when token verification fails' do
+          let(:oidc_request) { create_oidc_request(state: "state-bad-token") }
+          let(:body) { { state: oidc_request.state, code: "authorization-code" } }
+
+          before do
+            stub_provider_config
+            stub_discovery
+
+            fake_access_token = instance_double(OpenIDConnect::AccessToken, id_token: "fake.id.token")
+            allow_any_instance_of(OpenIDConnect::Client).to receive(:access_token!).and_return(fake_access_token)
+
+            allow(OpenIDConnect::ResponseObject::IdToken).to receive(:decode)
+                                                               .and_raise(OpenIDConnect::ResponseObject::IdToken::InvalidToken.new("invalid signature"))
+          end
+
+          run_test! do |response|
+            json = JSON.parse(response.body)
+            expect(json["error"]).to eq("Authentication failed")
           end
         end
 
@@ -270,54 +339,25 @@ RSpec.describe OidcLoginController, type: :request do
 
           run_test! do |response|
             json = JSON.parse(response.body)
-            expect(json["error"]).to eq("Unknown OIDC provider: deleted-provider")
+            expect(json["error"]).to eq("Authentication failed")
           end
         end
       end
 
-      # ── 422 — invalid or expired state ──
+      # ── 400 — missing required parameters ──
 
-      response '422', 'invalid or expired login request' do
+      response '400', 'missing required parameters' do
         schema type: :object,
                properties: {
-                 error: { type: :string, example: 'Invalid or expired login request' }
+                 error: { type: :string, example: 'param is missing or the value is empty: state' }
                },
                required: %w[error]
 
-        let(:body) { { state: "nonexistent-state", code: "authorization-code" } }
+        let(:body) { { code: "authorization-code" } }
 
         run_test! do |response|
           json = JSON.parse(response.body)
-          expect(json["error"]).to eq("Invalid or expired login request")
-        end
-      end
-
-      # ── 401 — token verification failed ──
-
-      response '401', 'token verification failed' do
-        schema type: :object,
-               properties: {
-                 error: { type: :string, example: 'Token verification failed: invalid signature' }
-               },
-               required: %w[error]
-
-        let(:oidc_request) { create_oidc_request(state: "state-bad-token") }
-        let(:body) { { state: oidc_request.state, code: "authorization-code" } }
-
-        before do
-          stub_provider_config
-          stub_discovery
-
-          fake_access_token = instance_double(OpenIDConnect::AccessToken, id_token: "fake.id.token")
-          allow_any_instance_of(OpenIDConnect::Client).to receive(:access_token!).and_return(fake_access_token)
-
-          allow(OpenIDConnect::ResponseObject::IdToken).to receive(:decode)
-                                                             .and_raise(OpenIDConnect::ResponseObject::IdToken::InvalidToken.new("invalid signature"))
-        end
-
-        run_test! do |response|
-          json = JSON.parse(response.body)
-          expect(json["error"]).to match(/Token verification failed/)
+          expect(json["error"]).to match(/state/)
         end
       end
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -2317,6 +2317,7 @@ paths:
       summary: Logs in a user
       tags:
       - Authentication
+      security: []
       parameters: []
       responses:
         '200':

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -2370,9 +2370,10 @@ paths:
       - OIDC Authentication
       security: []
       description: |
-        Accepts a provider key, performs OIDC discovery, generates PKCE and state parameters,
-        persists an OidcRequest for later verification, and returns the provider's authorization URL
-        that the front end should redirect the user to.
+        Accepts a provider key and username, performs OIDC discovery, generates PKCE and state
+        parameters, persists an OidcRequest for later verification, and returns the provider's
+        authorization URL that the front end should redirect the user to.
+        Username is required because emails are not unique in Expertiza.
       parameters: []
       responses:
         '200':
@@ -2387,6 +2388,18 @@ paths:
                     example: https://accounts.google.com/o/oauth2/v2/auth?client_id=...&scope=openid+email+profile&state=...&nonce=...
                 required:
                 - redirect_uri
+        '400':
+          description: missing required parameters
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: 'param is missing or the value is empty: username'
+                required:
+                - error
         '404':
           description: unknown OIDC provider
           content:
@@ -2421,8 +2434,13 @@ paths:
                   type: string
                   example: google-ncsu
                   description: Key identifying the OIDC provider
+                username:
+                  type: string
+                  example: jdoe
+                  description: Expertiza username for account matching
               required:
               - provider
+              - username
   "/auth/callback":
     post:
       summary: Exchange an OIDC authorization code for a session token
@@ -2432,7 +2450,8 @@ paths:
       description: |
         Called by the front end after the user is redirected back from the identity provider.
         Exchanges the authorization code for tokens, verifies the ID token, and returns
-        a local JWT session token if the user's email matches an existing account.
+        a local JWT session token if the user's username and email match an existing account.
+        Returns a generic error for all failure modes to avoid information leakage.
       parameters: []
       responses:
         '200':
@@ -2447,32 +2466,8 @@ paths:
                     description: JWT session token
                 required:
                 - token
-        '404':
-          description: no account found or unknown provider
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    example: No account found for unknown@example.com
-                required:
-                - error
-        '422':
-          description: invalid or expired login request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    example: Invalid or expired login request
-                required:
-                - error
         '401':
-          description: token verification failed
+          description: authentication failed
           content:
             application/json:
               schema:
@@ -2480,7 +2475,19 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: 'Token verification failed: invalid signature'
+                    example: Authentication failed
+                required:
+                - error
+        '400':
+          description: missing required parameters
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: 'param is missing or the value is empty: state'
                 required:
                 - error
         '502':


### PR DESCRIPTION
Email addresses are not unique in Expertiza; multiple users can share the same email. Since email is the only identity claim available from OIDC providers, the system cannot reliably determine which local account to match without additional input. Storing the username provided before the OIDC flow allows the backend to match on both username and verified email during callback.

<img width="868" height="732" alt="image" src="https://github.com/user-attachments/assets/094ee236-ef18-4c04-92cc-5dbae39c373d" />
