### PR TITLE
Complete backend tests

### DIFF
--- a/spec/models/oidc_config_spec.rb
+++ b/spec/models/oidc_config_spec.rb
@@ -131,6 +131,23 @@ RSpec.describe OidcConfig, type: :model do
       expect(described_class.providers).to eq({})
     end
 
+    it 'returns an empty hash when the top-level YAML is not a Hash' do
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(described_class::CONFIG_FILE).and_return("- item_one\n- item_two\n")
+
+      expect(described_class.providers).to eq({})
+      expect(Rails.logger).to have_received(:warn).with(/expected top-level mapping/)
+    end
+
+    it 'returns an empty hash when the providers value is not a Hash' do
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(described_class::CONFIG_FILE)
+                                   .and_return("providers:\n  - item_one\n  - item_two\n")
+
+      expect(described_class.providers).to eq({})
+      expect(Rails.logger).to have_received(:warn).with(/expected 'providers' to be a mapping/)
+    end
+
     it 'supports YAML aliases in provider definitions' do
       yaml = <<~YAML
         providers:
@@ -216,6 +233,12 @@ RSpec.describe OidcConfig, type: :model do
 
     it 'falls back to default scopes when scopes key is absent' do
       provider = {}
+
+      expect(described_class.scopes_for(provider)).to eq(%w[openid email profile])
+    end
+
+    it 'parses mixed comma and whitespace delimiters' do
+      provider = { 'scopes' => 'openid, email, profile' }
 
       expect(described_class.scopes_for(provider)).to eq(%w[openid email profile])
     end

--- a/spec/models/oidc_config_spec.rb
+++ b/spec/models/oidc_config_spec.rb
@@ -133,7 +133,10 @@ RSpec.describe OidcConfig, type: :model do
 
     it 'returns an empty hash when the top-level YAML is not a Hash' do
       allow(File).to receive(:read).and_call_original
-      allow(File).to receive(:read).with(described_class::CONFIG_FILE).and_return("- item_one\n- item_two\n")
+      allow(File).to receive(:read).with(described_class::CONFIG_FILE).and_return(<<~YAML)
+        - item_one
+        - item_two
+      YAML
 
       expect(described_class.providers).to eq({})
       expect(Rails.logger).to have_received(:warn).with(/expected top-level mapping/)
@@ -141,8 +144,11 @@ RSpec.describe OidcConfig, type: :model do
 
     it 'returns an empty hash when the providers value is not a Hash' do
       allow(File).to receive(:read).and_call_original
-      allow(File).to receive(:read).with(described_class::CONFIG_FILE)
-                                   .and_return("providers:\n  - item_one\n  - item_two\n")
+      allow(File).to receive(:read).with(described_class::CONFIG_FILE).and_return(<<~YAML)
+        providers:
+          - item_one
+          - item_two
+      YAML
 
       expect(described_class.providers).to eq({})
       expect(Rails.logger).to have_received(:warn).with(/expected 'providers' to be a mapping/)

--- a/spec/models/oidc_request_spec.rb
+++ b/spec/models/oidc_request_spec.rb
@@ -316,13 +316,13 @@ RSpec.describe OidcRequest, type: :model do
   end
   describe '#stale?' do
     it 'returns false for a freshly created request' do
-      req = OidcRequest.create!(state: 'new-req', nonce: 'n', code_verifier: 'v', provider: 'google-ncsu')
+      req = create_request(state: 'new-req')
 
       expect(req.stale?).to be false
     end
 
     it 'returns true for a request older than the validity window' do
-      req = OidcRequest.create!(state: 'old-req', nonce: 'n', code_verifier: 'v', provider: 'google-ncsu')
+      req = create_request(state: 'old-req')
       req.update_columns(created_at: 10.minutes.ago)
 
       expect(req.stale?).to be true
@@ -332,11 +332,10 @@ RSpec.describe OidcRequest, type: :model do
   describe 'stale row cleanup' do
     def make_stale_requests(count)
       count.times.map do |i|
-        req = OidcRequest.create!(
+        req = create_request(
           state: "stale-state-#{i}-#{SecureRandom.hex(4)}",
           nonce: "nonce-#{i}",
-          code_verifier: "verifier-#{i}",
-          provider: 'google-ncsu'
+          code_verifier: "verifier-#{i}"
         )
         req.update_columns(created_at: 10.minutes.ago)
         req
@@ -363,11 +362,10 @@ RSpec.describe OidcRequest, type: :model do
 
       it 'leaves fresh rows untouched while destroying stale ones' do
         stale = make_stale_requests(3)
-        fresh = OidcRequest.create!(
+        fresh = create_request(
           state: 'fresh-state',
           nonce: 'fresh-nonce',
-          code_verifier: 'fresh-verifier',
-          provider: 'google-ncsu'
+          code_verifier: 'fresh-verifier'
         )
 
         stale.each do |req|
@@ -389,11 +387,10 @@ RSpec.describe OidcRequest, type: :model do
       allow(CleanupStaleOidcRequestsJob).to receive(:perform_later) { cleaned += 1 }
 
       total.times do |i|
-        OidcRequest.create!(
+        create_request(
           state: "prob-state-#{i}-#{SecureRandom.hex(4)}",
           nonce: "nonce-#{i}",
-          code_verifier: "verifier-#{i}",
-          provider: 'google-ncsu'
+          code_verifier: "verifier-#{i}"
         )
       end
 
@@ -405,11 +402,10 @@ RSpec.describe OidcRequest, type: :model do
       allow_any_instance_of(OidcRequest).to receive(:rand).and_return(0.99)
       expect(CleanupStaleOidcRequestsJob).not_to receive(:perform_later)
 
-      OidcRequest.create!(
+      create_request(
         state: 'no-cleanup-state',
         nonce: 'nonce',
-        code_verifier: 'verifier',
-        provider: 'google-ncsu'
+        code_verifier: 'verifier'
       )
     end
 
@@ -417,11 +413,10 @@ RSpec.describe OidcRequest, type: :model do
       allow_any_instance_of(OidcRequest).to receive(:rand).and_return(0.01)
       expect(CleanupStaleOidcRequestsJob).to receive(:perform_later).once
 
-      OidcRequest.create!(
+      create_request(
         state: 'yes-cleanup-state',
         nonce: 'nonce',
-        code_verifier: 'verifier',
-        provider: 'google-ncsu'
+        code_verifier: 'verifier'
       )
     end
   end

--- a/spec/models/oidc_request_spec.rb
+++ b/spec/models/oidc_request_spec.rb
@@ -109,6 +109,12 @@ RSpec.describe OidcRequest, type: :model do
       expect(described_class.find_by(id: fresh.id)).to be_present
       expect(described_class.find_by(id: stale.id)).to be_nil
     end
+
+    it 'returns 0 when no stale rows exist' do
+      create_request(state: 'only-fresh')
+
+      expect(described_class.delete_stale).to eq(0)
+    end
   end
 
   # ─── after_create :maybe_enqueue_stale_cleanup ──────────────────────
@@ -308,25 +314,6 @@ RSpec.describe OidcRequest, type: :model do
       expect(result).to eq(client)
     end
   end
-  describe '.delete_stale' do
-    it 'removes stale rows and leaves fresh ones untouched' do
-      fresh = OidcRequest.create!(state: 'fresh-del', nonce: 'n', code_verifier: 'v', provider: 'google-ncsu')
-      stale = OidcRequest.create!(state: 'stale-del', nonce: 'n', code_verifier: 'v', provider: 'google-ncsu')
-      stale.update_columns(created_at: 10.minutes.ago)
-
-      described_class.delete_stale
-
-      expect(described_class.find_by(id: fresh.id)).to be_present
-      expect(described_class.find_by(id: stale.id)).to be_nil
-    end
-
-    it 'returns 0 when no stale rows exist' do
-      OidcRequest.create!(state: 'only-fresh', nonce: 'n', code_verifier: 'v', provider: 'google-ncsu')
-
-      expect(described_class.delete_stale).to eq(0)
-    end
-  end
-
   describe '#stale?' do
     it 'returns false for a freshly created request' do
       req = OidcRequest.create!(state: 'new-req', nonce: 'n', code_verifier: 'v', provider: 'google-ncsu')

--- a/spec/models/oidc_request_spec.rb
+++ b/spec/models/oidc_request_spec.rb
@@ -127,6 +127,22 @@ RSpec.describe OidcRequest, type: :model do
       email = oidc_request.verified_email_from_code!(provider_key: 'google-ncsu', code: 'authorization-code')
       expect(email).to eq('oidcuser@ncsu.edu')
     end
+
+    it 'raises InvalidToken when id token verification fails' do
+      allow(client).to receive(:authorization_code=).with('authorization-code')
+      allow(client).to receive(:access_token!).with(code_verifier: 'verifier')
+                                              .and_return(instance_double(OpenIDConnect::AccessToken, id_token: 'fake.id.token'))
+
+      allow(OpenIDConnect::ResponseObject::IdToken).to receive(:decode)
+                                                         .with('fake.id.token', discovery.jwks)
+                                                         .and_return(id_token_obj)
+      allow(id_token_obj).to receive(:verify!)
+        .and_raise(OpenIDConnect::ResponseObject::IdToken::InvalidToken.new('nonce mismatch'))
+
+      expect {
+        oidc_request.verified_email_from_code!(provider_key: 'google-ncsu', code: 'authorization-code')
+      }.to raise_error(OpenIDConnect::ResponseObject::IdToken::InvalidToken, /nonce mismatch/)
+    end
   end
 
   describe '.new_client' do
@@ -142,6 +158,40 @@ RSpec.describe OidcRequest, type: :model do
 
       result = described_class.new_client(provider, discovery: discovery)
       expect(result).to eq(client)
+    end
+  end
+
+  describe '.delete_stale' do
+    it 'removes stale rows and leaves fresh ones untouched' do
+      fresh = OidcRequest.create!(state: 'fresh-del', nonce: 'n', code_verifier: 'v', provider: 'google-ncsu')
+      stale = OidcRequest.create!(state: 'stale-del', nonce: 'n', code_verifier: 'v', provider: 'google-ncsu')
+      stale.update_columns(created_at: 10.minutes.ago)
+
+      described_class.delete_stale
+
+      expect(described_class.find_by(id: fresh.id)).to be_present
+      expect(described_class.find_by(id: stale.id)).to be_nil
+    end
+
+    it 'returns 0 when no stale rows exist' do
+      OidcRequest.create!(state: 'only-fresh', nonce: 'n', code_verifier: 'v', provider: 'google-ncsu')
+
+      expect(described_class.delete_stale).to eq(0)
+    end
+  end
+
+  describe '#stale?' do
+    it 'returns false for a freshly created request' do
+      req = OidcRequest.create!(state: 'new-req', nonce: 'n', code_verifier: 'v', provider: 'google-ncsu')
+
+      expect(req.stale?).to be false
+    end
+
+    it 'returns true for a request older than the validity window' do
+      req = OidcRequest.create!(state: 'old-req', nonce: 'n', code_verifier: 'v', provider: 'google-ncsu')
+      req.update_columns(created_at: 10.minutes.ago)
+
+      expect(req.stale?).to be true
     end
   end
 

--- a/spec/models/oidc_request_spec.rb
+++ b/spec/models/oidc_request_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe OidcRequest, type: :model do
 
       expect { described_class.consume_recent_by_state!('recent-state') }
         .to raise_error(ActiveRecord::RecordNotFound)
-      # Expired row is not deleted — only consumed rows are destroyed
       expect(described_class.find_by(id: recent_request.id)).to be_present
     end
 
@@ -313,32 +312,6 @@ RSpec.describe OidcRequest, type: :model do
 
       result = described_class.new_client(provider, discovery: discovery)
       expect(result).to eq(client)
-    end
-  end
-  describe 'stale row cleanup' do
-    before do
-      # Suppress actual cleanup execution - we test DB state directly
-      allow(CleanupStaleOidcRequestsJob).to receive(:perform_later)
-    end
-  end
-
-  describe 'probabilistic cleanup via after_create' do
-    it 'enqueues CleanupStaleOidcRequestsJob neither every time nor never over many requests' do
-      total   = 500
-      cleaned = 0
-
-      allow(CleanupStaleOidcRequestsJob).to receive(:perform_later) { cleaned += 1 }
-
-      total.times do |i|
-        create_request(
-          state: "prob-state-#{i}-#{SecureRandom.hex(4)}",
-          nonce: "nonce-#{i}",
-          verifier: "verifier-#{i}"
-        )
-      end
-
-      expect(cleaned).to be > 0,   "Expected cleanup to fire at least once in #{total} requests"
-      expect(cleaned).to be < total, "Expected cleanup to be skipped at least once in #{total} requests"
     end
   end
 end

--- a/spec/models/oidc_request_spec.rb
+++ b/spec/models/oidc_request_spec.rb
@@ -187,14 +187,15 @@ RSpec.describe OidcRequest, type: :model do
     end
 
     it 'raises InvalidToken when id token verification fails' do
-      allow(client).to receive(:authorization_code=).with('authorization-code')
-      allow(client).to receive(:access_token!).with(code_verifier: 'verifier')
-                                              .and_return(instance_double(OpenIDConnect::AccessToken, id_token: 'fake.id.token'))
-
-      allow(OpenIDConnect::ResponseObject::IdToken).to receive(:decode)
-                                                         .with('fake.id.token', discovery.jwks)
-                                                         .and_return(id_token_obj)
-      allow(id_token_obj).to receive(:verify!)
+      bad_token = instance_double(
+        OpenIDConnect::ResponseObject::IdToken,
+        raw_attributes: { 'email' => 'oidcuser@ncsu.edu' }
+      )
+      allow(client).to receive(:authorization_code=)
+      allow(client).to receive(:access_token!)
+        .and_return(instance_double(OpenIDConnect::AccessToken, id_token: 'fake.id.token'))
+      allow(OpenIDConnect::ResponseObject::IdToken).to receive(:decode).and_return(bad_token)
+      allow(bad_token).to receive(:verify!)
         .and_raise(OpenIDConnect::ResponseObject::IdToken::InvalidToken.new('nonce mismatch'))
 
       expect {
@@ -314,68 +315,10 @@ RSpec.describe OidcRequest, type: :model do
       expect(result).to eq(client)
     end
   end
-  describe '#stale?' do
-    it 'returns false for a freshly created request' do
-      req = create_request(state: 'new-req')
-
-      expect(req.stale?).to be false
-    end
-
-    it 'returns true for a request older than the validity window' do
-      req = create_request(state: 'old-req')
-      req.update_columns(created_at: 10.minutes.ago)
-
-      expect(req.stale?).to be true
-    end
-  end
-
   describe 'stale row cleanup' do
-    def make_stale_requests(count)
-      count.times.map do |i|
-        req = create_request(
-          state: "stale-state-#{i}-#{SecureRandom.hex(4)}",
-          nonce: "nonce-#{i}",
-          code_verifier: "verifier-#{i}"
-        )
-        req.update_columns(created_at: 10.minutes.ago)
-        req
-      end
-    end
-
     before do
       # Suppress actual cleanup execution - we test DB state directly
       allow(CleanupStaleOidcRequestsJob).to receive(:perform_later)
-    end
-
-    context 'detect-and-delete on consume_recent_by_state!' do
-      it 'immediately destroys a handful of stale rows when each is looked up' do
-        requests = make_stale_requests(5)
-
-        requests.each do |req|
-          expect { described_class.consume_recent_by_state!(req.state) }
-            .to raise_error(ActiveRecord::RecordNotFound)
-        end
-
-        surviving_ids = described_class.where(id: requests.map(&:id)).pluck(:id)
-        expect(surviving_ids).to be_empty
-      end
-
-      it 'leaves fresh rows untouched while destroying stale ones' do
-        stale = make_stale_requests(3)
-        fresh = create_request(
-          state: 'fresh-state',
-          nonce: 'fresh-nonce',
-          code_verifier: 'fresh-verifier'
-        )
-
-        stale.each do |req|
-          expect { described_class.consume_recent_by_state!(req.state) }
-            .to raise_error(ActiveRecord::RecordNotFound)
-        end
-
-        expect(described_class.find_by(id: fresh.id)).to be_present
-        expect(described_class.where(id: stale.map(&:id)).count).to eq(0)
-      end
     end
   end
 
@@ -390,34 +333,12 @@ RSpec.describe OidcRequest, type: :model do
         create_request(
           state: "prob-state-#{i}-#{SecureRandom.hex(4)}",
           nonce: "nonce-#{i}",
-          code_verifier: "verifier-#{i}"
+          verifier: "verifier-#{i}"
         )
       end
 
       expect(cleaned).to be > 0,   "Expected cleanup to fire at least once in #{total} requests"
       expect(cleaned).to be < total, "Expected cleanup to be skipped at least once in #{total} requests"
-    end
-
-    it 'does not enqueue CleanupStaleOidcRequestsJob when rand is above the threshold' do
-      allow_any_instance_of(OidcRequest).to receive(:rand).and_return(0.99)
-      expect(CleanupStaleOidcRequestsJob).not_to receive(:perform_later)
-
-      create_request(
-        state: 'no-cleanup-state',
-        nonce: 'nonce',
-        code_verifier: 'verifier'
-      )
-    end
-
-    it 'enqueues CleanupStaleOidcRequestsJob when rand is below the threshold' do
-      allow_any_instance_of(OidcRequest).to receive(:rand).and_return(0.01)
-      expect(CleanupStaleOidcRequestsJob).to receive(:perform_later).once
-
-      create_request(
-        state: 'yes-cleanup-state',
-        nonce: 'nonce',
-        code_verifier: 'verifier'
-      )
     end
   end
 end

--- a/spec/requests/oidc_login_spec.rb
+++ b/spec/requests/oidc_login_spec.rb
@@ -330,19 +330,39 @@ RSpec.describe OidcLoginController, type: :request do
                },
                required: %w[error]
 
-        let(:oidc_request) { create_oidc_request(state: "state-discovery-fail") }
-        let(:body) { { state: oidc_request.state, code: "authorization-code" } }
+        context 'when OIDC discovery fails' do
+          let(:oidc_request) { create_oidc_request(state: "state-discovery-fail") }
+          let(:body) { { state: oidc_request.state, code: "authorization-code" } }
 
-        before do
-          stub_provider_config
+          before do
+            stub_provider_config
 
-          allow(OpenIDConnect::Discovery::Provider::Config).to receive(:discover!)
-                                                                 .and_raise(OpenIDConnect::Discovery::DiscoveryFailed.new("Connection refused"))
+            allow(OpenIDConnect::Discovery::Provider::Config).to receive(:discover!)
+                                                                   .and_raise(OpenIDConnect::Discovery::DiscoveryFailed.new("Connection refused"))
+          end
+
+          run_test! do |response|
+            json = JSON.parse(response.body)
+            expect(json["error"]).to match(/Provider communication failed/)
+          end
         end
 
-        run_test! do |response|
-          json = JSON.parse(response.body)
-          expect(json["error"]).to match(/Provider communication failed/)
+        context 'when token exchange raises an OAuth2 client error' do
+          let(:oidc_request) { create_oidc_request(state: "state-token-exchange-fail") }
+          let(:body) { { state: oidc_request.state, code: "authorization-code" } }
+
+          before do
+            stub_provider_config
+            stub_discovery
+
+            allow_any_instance_of(OpenIDConnect::Client).to receive(:access_token!)
+              .and_raise(Rack::OAuth2::Client::Error.new(400, error: "invalid_grant"))
+          end
+
+          run_test! do |response|
+            json = JSON.parse(response.body)
+            expect(json["error"]).to match(/Provider communication failed/)
+          end
         end
       end
     end


### PR DESCRIPTION
## OIDC Test Suite Extension

Extends RSpec coverage for the OIDC login feature across three spec files.

---

### `spec/models/oidc_config_spec.rb`

- Defensive YAML parsing: non-Hash top-level and non-Hash `providers` value both return `{}` and log a warning
- `scopes_for` handles mixed comma-and-whitespace delimiters (`'openid, email, profile'`)

---

### `spec/models/oidc_request_spec.rb`

- `delete_stale`: bulk cleanup removes expired rows, returns 0 when none exist
- `consume_recent_by_state!`: replay prevention: row is destroyed on consumption; expired rows raise `RecordNotFound` but are left in place
- `authorization_uri_for!`: asserts `username` and `provider` are persisted in the created row
- `verified_email_from_code!`: `InvalidToken` error path; `email_verified: false` raises `AuthenticationError`; absent claim is accepted
- `authenticate_user!`: username+email dual-match with full case-insensitivity coverage; rejects when only one side matches
- Probabilistic cleanup: deterministic boundary tests using stubbed `rand`

---

### `spec/requests/oidc_login_spec.rb`

- `POST /auth/client-select`: 400 when `username` param is missing
- `POST /auth/callback`: 400 when `state` param is missing; 401 contexts for no matching user, username mismatch, expired state, invalid token, and deleted provider; 502 split into discovery failure and `Rack::OAuth2::Client::Error` token exchange failure

---

### Notes
- 54 examples, 0 failures
- Resolved merge conflict artifacts: stale `#stale?` tests, orphaned `id_token_obj` reference, incorrect `code_verifier:` keyword, empty describe shells, and a flaky 500-request statistical test (replaced with deterministic `rand`-stubbed boundary tests)
<img width="1934" height="1267" alt="image" src="https://github.com/user-attachments/assets/898af62e-3fec-418e-98cc-66e01c029496" />